### PR TITLE
Allow actual vocab to run slightly over max

### DIFF
--- a/caffe2/python/examples/seq2seq_data.py
+++ b/caffe2/python/examples/seq2seq_data.py
@@ -41,7 +41,7 @@ def gen_vocab(filename, max_size):
 
     vocab = {PAD: 0, GO: 1, EOS: 2, UNK: 3}
     i = 4
-    for key, count in counter.most_common(max_size - len(vocab)):
+    for key, count in counter.most_common(max_size):
         vocab[key] = i
         i += 1
     assert len(vocab.keys()) <= max_size


### PR DESCRIPTION
I was restricting the vocab blob to 50,000. Looks like the previous code restricted to 50,004. Not sure which is intended. My intuition was to make the total vocab size exactly equal to 50,000, for better GPU utilization?